### PR TITLE
Add health check to vLLM wrapper models

### DIFF
--- a/models/vllm/Dockerfile
+++ b/models/vllm/Dockerfile
@@ -66,12 +66,18 @@ RUN apt-get update -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+COPY requirements.ready requirements.ready
+RUN pip install -r requirements.ready
+
 SHELL ["/bin/bash", "--login", "-i", "-c"]
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 RUN source /root/.bashrc && nvm install --lts
 
 COPY --from=app_builder /workdir/chatbot-ui chatbot-ui
 RUN npm i --prefix chatbot-ui
+
+COPY ready.py ready.py
+EXPOSE 5000
 
 EXPOSE 3000
 COPY app.sh app.sh

--- a/models/vllm/README.md
+++ b/models/vllm/README.md
@@ -25,9 +25,9 @@ Optional build args:
 ## Running the Docker image
 Running the application is done with the following command:
 ```
-docker run --rm --gpus all -p 3000:3000 run-ai/vllm:Llama-2-7b-chat-hf
+docker run --rm --gpus all -p 3000:3000 -p 5000:5000 run-ai/vllm:Llama-2-7b-chat-hf
 ```
-To run the server only image change the port to 8000.
+To run the server only image change the port to 8000, and dont expose port 5000.
 
 ## Usage
 
@@ -39,4 +39,10 @@ curl http://localhost:8000/v1/completions -H "Content-Type: application/json" -d
 Using the application with the app image browse to:
 ```
 http://localhost:3000
+```
+
+### Readiness
+When running the app, you can check the readiness of the application with the following request:
+```
+curl http://localhost:5000/ready
 ```

--- a/models/vllm/README.md
+++ b/models/vllm/README.md
@@ -25,10 +25,12 @@ Optional build args:
 ## Running the Docker image
 Running the application is done with the following command:
 ```
-docker run --rm --gpus all -p 3000:3000 -p 5000:5000 run-ai/vllm:Llama-2-7b-chat-hf
+docker run --rm --gpus all -p 3000:3000 -p 3001:3001 run-ai/vllm:Llama-2-7b-chat-hf
 ```
-To run the server only image change the port to 8000, and dont expose port 5000.
+To run the server only image change the port to 8000, and dont expose port 3001.
 
+
+If you wish to run the readiness server on different port than 3001, you can specify it with `-e READINESS_PORT=PORT`
 ## Usage
 
 Using the model for completion example with server image:
@@ -44,5 +46,5 @@ http://localhost:3000
 ### Readiness
 When running the app, you can check the readiness of the application with the following request:
 ```
-curl http://localhost:5000/ready
+curl http://localhost:3001/ready
 ```

--- a/models/vllm/app.sh
+++ b/models/vllm/app.sh
@@ -1,3 +1,4 @@
 bash -c "python3 -m vllm.entrypoints.openai.api_server --model /model --served-model-name ${NAME}" &
 bash -i -c "npm run dev --prefix chatbot-ui" &
+bash -c "python3 ready.py" &
 wait

--- a/models/vllm/ready.py
+++ b/models/vllm/ready.py
@@ -1,20 +1,24 @@
+import os
 from flask import Flask, jsonify
 import requests
 
 app = Flask(__name__)
+port = int(os.getenv("PORT", 3000))
+flask_port = int(os.getenv("READINESS_PORT", "3001"))
 
 @app.route('/ready')
 def check_ready():
     try:
-        response1 = requests.post('http://localhost:3000/api/models', data="{}", timeout=60)
+        response1 = requests.post(f'http://localhost:{port}/api/models', data="{}", timeout=60)
         response2 = requests.get('http://localhost:8000/v1/models', timeout=60)
 
-        if response1.status_code == 200 and response2.status_code == 200:
+        if response1.status_code != 200 or response2.status_code != 200:
+            return jsonify({'message': 'Endpoints are not ready'}), 503
+        else:
             return jsonify({'message': 'Both endpoints are ready'}), 200
-    except:
-        pass
-    return jsonify({'message': 'Endpoints are not ready'}), 503
+    except Exception as e:
+        return jsonify({'message': 'Endpoints are not ready'}), 503
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0')
+    app.run(host='0.0.0.0', port=flask_port)
 

--- a/models/vllm/ready.py
+++ b/models/vllm/ready.py
@@ -1,0 +1,20 @@
+from flask import Flask, jsonify
+import requests
+
+app = Flask(__name__)
+
+@app.route('/ready')
+def check_ready():
+    try:
+        response1 = requests.post('http://localhost:3000/api/models', data="{}", timeout=60)
+        response2 = requests.get('http://localhost:8000/v1/models', timeout=60)
+
+        if response1.status_code == 200 and response2.status_code == 200:
+            return jsonify({'message': 'Both endpoints are ready'}), 200
+    except:
+        pass
+    return jsonify({'message': 'Endpoints are not ready'}), 503
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0')
+

--- a/models/vllm/requirements.ready
+++ b/models/vllm/requirements.ready
@@ -1,0 +1,2 @@
+requests==2.31.0
+Flask==3.0.2


### PR DESCRIPTION
In this PR we introduce a new API for the vLLM wrapper:
Readiness API - Which returns 200OK only if both vLLM and Chatbot-UI are ready to serve requests.
It does not exists if you build only vLLM layer image.

We do it by adding a new application that will have HTTP server that encapsulate the readiness logic.
This PR adds this server and its pip requirements:
* `ready.py`
* `requirements.ready`

Install it as part of the Dockerfile:
* `Dockerfile`
* `app.sh`

And document how to use it:
* `README.md`