### PR TITLE
Update entrypoint for triton-server 24.07

### DIFF
--- a/models/triton/server/Dockerfile
+++ b/models/triton/server/Dockerfile
@@ -8,4 +8,4 @@ RUN cd / && \
 # expose the HTTP port
 EXPOSE 8000
 
-ENTRYPOINT ["/opt/tritonserver/nvidia_entrypoint.sh", "tritonserver", "--model-repository", "/triton-inference-server/docs/examples/model_repository"]
+ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh", "tritonserver", "--model-repository", "/triton-inference-server/docs/examples/model_repository"]


### PR DESCRIPTION
Entrypoint has moved in the image. Tested this locally.