### PR TITLE
Update Dockerfile to fix permissions error

### DIFF
--- a/models/triton/server/Dockerfile
+++ b/models/triton/server/Dockerfile
@@ -1,9 +1,11 @@
 FROM nvcr.io/nvidia/tritonserver:24.07-py3
 
 RUN cd / && \
-    git clone https://github.com/triton-inference-server/server.git triton-inference-server && \
+    git clone https://github.com/wcarrollrai/server.git triton-inference-server && \
     cd /triton-inference-server/docs/examples && \
-    ./fetch_models.sh
+    ./fetch_models.sh && \
+    chown root:root /triton-inference-server/docs/examples/model_repository/inception_graphdef/1/model.graphdef && \
+    chmod 644 /triton-inference-server/docs/examples/model_repository/inception_graphdef/1/model.graphdef
 
 # expose the HTTP port
 EXPOSE 8000


### PR DESCRIPTION
Updated the Dockerfile to point to a custom repo as there is an issue https://github.com/triton-inference-server/server/issues/7630 with the official fetch_models.sh script. Also added a permissions fix for the inception_graphdef model as the owner and group were incorrect and the lack of read permissions for the "other" group was set to 0.